### PR TITLE
Bug 1379823 - Create a `crash_rates` dataset for MacroBase evaluation

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,40 @@
+# Data
+
+## `crash_rates.v1`
+
+The data processing notebook stores data in the following directory:
+
+```
+s3://net-mozaws-prod-us-west-2-pipeline-analysis/amiyaguchi/macrobase/crash_rates/v1
+```
+
+It contains the following fields, as of `v1`.
+
+```
+root
+ |-- timestamp: long (nullable = true)
+ |-- sample_id: string (nullable = true)
+ |-- normalized_channel: string (nullable = true)
+ |-- env_build_version: string (nullable = true)
+ |-- env_build_id: string (nullable = true)
+ |-- app_name: string (nullable = true)
+ |-- os: string (nullable = true)
+ |-- os_version: string (nullable = true)
+ |-- env_build_arch: string (nullable = true)
+ |-- country: string (nullable = true)
+ |-- active_experiment_id: string (nullable = true)
+ |-- active_experiment_branch: string (nullable = true)
+ |-- e10s_enabled: boolean (nullable = true)
+ |-- e10s_cohort: string (nullable = true)
+ |-- gfx_compositor: string (nullable = true)
+ |-- usage_khours: double (nullable = true)
+ |-- crashes_detected_content: integer (nullable = true)
+ |-- crashes_detected_plugin: integer (nullable = true)
+ |-- crashes_detected_gmplugin: integer (nullable = true)
+ |-- crashes_detected_content_rate: double (nullable = true)
+ |-- crashes_detected_plugin_rate: double (nullable = true)
+ |-- crashes_detected_gmplugin_rate: double (nullable = true)
+ |-- submission_day: integer (nullable = true)
+ |-- submission_date_s3: string (nullable = true)
+
+```

--- a/notebooks/Crash_Rates_ETL.ipynb
+++ b/notebooks/Crash_Rates_ETL.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Crash Rates ETL\n",
+    "## Anomaly Detection and Explanation of Crash Rates"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will be observing crash rates, with metrics dervived from the [e10s stability dashboard][1]. The crash rate is defined as\n",
+    "\n",
+    "$$\n",
+    "\\text{rate} = \\frac\n",
+    "    {\\text{# crashes}}\n",
+    "    {\\text{usage khours}}\n",
+    "$$\n",
+    "\n",
+    "This definition provides a normalized crash rate that can be used to compare clients across segments. The stability dashboard also includes a color-coded table for comparing rates relative to the leading week's rate.\n",
+    "\n",
+    "[1]: https://chutten.github.io/telemetry-dashboard/crashes/ \"Stability Dashboard (Telemetry) - e10s\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "path = (\n",
+    "    \"s3://net-mozaws-prod-us-west-2-pipeline-analysis\"\n",
+    "    \"/amiyaguchi/macrobase/crash_rates/v1/\"\n",
+    ")\n",
+    "path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Preparation\n",
+    "\n",
+    "###  Feature Selection\n",
+    "#### Attribution Selection\n",
+    "The following features have been used for the e10s rollout, and should be useful for finding anomalous sub-populations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "attributes = [\n",
+    "    'normalized_channel',\n",
+    "    'env_build_version',\n",
+    "    'env_build_id',\n",
+    "    'app_name',\n",
+    "    'os',\n",
+    "    'os_version',\n",
+    "    'env_build_arch',\n",
+    "    'country',\n",
+    "    'active_experiment_id',\n",
+    "    'active_experiment_branch',\n",
+    "    'e10s_enabled',\n",
+    "    'e10s_cohort',\n",
+    "    'gfx_compositor',\n",
+    "    \"submission_date_s3\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "#### Metric Selection\n",
+    "\n",
+    "`usage_khours` are derived from the client subsession length. The three types of available crash counts in the main_summary dataset as of `main_summary/v4` are content, plugin, and gmplugin crashes. Finally, the crash rates are derived from the crash type and the `usage_khours`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "seconds_per_hour = 60 * 60\n",
+    "seconds_per_day = seconds_per_hour * 24\n",
+    "\n",
+    "def crash_rate(crashes, usage=\"usage_khours\"):\n",
+    "    return (\n",
+    "        (F.col(crashes) / F.col(usage))\n",
+    "        .alias(\"{}_rate\".format(crashes))\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "usage_khours = (\n",
+    "    F.when((F.col(\"subsession_length\") >= 0) &\n",
+    "           (F.col(\"subsession_length\") < 180 * seconds_per_day),\n",
+    "           (F.col(\"subsession_length\") / seconds_per_hour / 1000))\n",
+    "    .otherwise(0.0)\n",
+    "    .cast('double')\n",
+    "    .alias(\"usage_khours\")\n",
+    ")\n",
+    "\n",
+    "crash_fields = [\n",
+    "    \"crashes_detected_content\",\n",
+    "    \"crashes_detected_plugin\",\n",
+    "    \"crashes_detected_gmplugin\",\n",
+    "]\n",
+    "crash_metrics = crash_fields + [crash_rate(x) for x in crash_fields]\n",
+    "\n",
+    "metrics = [F.col(\"usage_khours\")] + crash_metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract relevant features from `main_summary`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import operator\n",
+    "\n",
+    "main_summary = (\n",
+    "    spark\n",
+    "    .read\n",
+    "    .option(\"mergeSchema\", \"true\")\n",
+    "    .parquet(\"s3://telemetry-parquet/main_summary/v4\")\n",
+    ")\n",
+    "\n",
+    "# take a 1% percent sample, bucket #27\n",
+    "crash_rates = (\n",
+    "    main_summary\n",
+    "    .where(F.col(\"sample_id\") == 27)\n",
+    "    .withColumn(\"usage_khours\", usage_khours)\n",
+    "    .select([\"timestamp\", \"sample_id\"] + attributes + metrics)\n",
+    "    .where(\n",
+    "        reduce(operator.__or__, \n",
+    "               [F.col(x).isNotNull() for x in crash_fields]))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Repartition and Persist data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "timestamp = F.from_unixtime(F.col(\"timestamp\")/10**9)\n",
+    "\n",
+    "crash_rates_by_day = (\n",
+    "    crash_rates\n",
+    "    .withColumn(\"submission_day\", F.dayofyear(timestamp))\n",
+    "    .orderBy(\"timestamp\")\n",
+    ")\n",
+    "\n",
+    "(\n",
+    "    crash_rates_by_day\n",
+    "    .write\n",
+    "    .partitionBy(\"submission_date_s3\")\n",
+    "    .parquet(path, mode=\"overwrite\")\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
[Bug 1379823 - Create a `crash_rates` dataset for MacroBase evaluation](https://bugzilla.mozilla.org/show_bug.cgi?id=1379823)

This dataset normalizes the notion of per-client, per-session crashes over session length for analysis across subpopulations. These rates should be compatible with the classification and explaination operators in MacroBase.