### PR TITLE
Bug 1379806 - Add instructions for running MacroBase GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # telemetry-macrobase-crash-rates
 
 Notebooks and code for reproducing macrobase analysis over Firefox telemetry data.
+
+## Quickstart
+
+The easiest way to explore the `crash_rates` dataset with MacroBase is to use the GUI.
+
+Follow the [tutorial](https://github.com/stanford-futuredata/macrobase/wiki/Tutorial) to download and package MacroBae.
+
+The `/data` folder contains instructions on how to obtain the `crash_rates` dataset, as well as some additional scripts for loading a docker image with the data.
+
+Replace step 3 with the following, with more detailed instructions in `/data`:
+
+* 3a. Download a preprocessed dataset -- `crash_rates.csv`
+* 3b. Build the `postgres-crash-rates` docker container
+* 3c. Append the line `macrobase.loader.db.user: postgres` to `macrobase/conf/macrobase.conf`
+
+The port of the postgres container can be found through `docker ps`
+
+Finally, once in the MacroBase GUI, replace `localhost` with `localhost:PORT`. `PORT` will be localized to your machine.
+

--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -1,0 +1,4 @@
+FROM postgres:9.6-alpine
+
+COPY crash_rates.csv .
+COPY import_crash_rates.sql /docker-entrypoint-initdb.d/

--- a/data/README.md
+++ b/data/README.md
@@ -1,4 +1,33 @@
 # Data
+## crash_rates postgres image
+
+This directory contains a dockerfile for building a postgres image with crash_rates data.
+
+```
+$ aws s3 cp s3://net-mozaws-prod-us-west-2-pipeline-analysis/amiyaguchi/macrobase/crash_rates.csv .
+$ docker build . -t postgres-crash-rates
+$ docker run --rm -P --name crash-rates-db postgres-crash-rates
+```
+
+`--rm` deletes the container on exit. `-P` exposes the docker port and maps it to a local port. Running `docker ps` shows this mapping.
+```
+$ docker ps
+CONTAINER ID        IMAGE                        COMMAND                  CREATED             STATUS                         PORTS                     NAMES
+49e2dc825e66        postgres-crash-rates         "docker-entrypoint..."   0 minutes ago       Up 0 minutes                   0.0.0.0:32772->5432/tcp   crash-rates-db
+```
+
+A local postgres client (`psql`) can be attached to this instance.
+```
+$ psql -h localhost -p 327772 -U postgres
+postgres-# \dt
+            List of relations
+ Schema |    Name     | Type  |  Owner
+--------+-------------+-------+----------
+ public | crash_rates | table | postgres
+(1 row)
+
+postgres-# SELECT * FROM crash_rates LIMIT 10
+```
 
 ## `crash_rates.v1`
 

--- a/data/import_crash_rates.sql
+++ b/data/import_crash_rates.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS crash_rates;
+
+CREATE TABLE crash_rates (
+       timestamp BIGINT,
+       normalized_channel VARCHAR,
+       env_build_version VARCHAR,
+       env_build_id VARCHAR,
+       app_name VARCHAR,
+       os VARCHAR,
+       os_version VARCHAR,
+       env_build_arch VARCHAR,
+       country VARCHAR,
+       active_experiment_id VARCHAR,
+       active_experiment_branch VARCHAR,
+       e10s_enabled VARCHAR,
+       e10s_cohort VARCHAR,
+       gfx_compositor VARCHAR,
+       crashes_detected_content_rate DOUBLE PRECISION,
+       crashes_detected_plugin_rate DOUBLE PRECISION,
+       crashes_detected_gmplugin_rate DOUBLE PRECISION
+);
+
+COPY crash_rates FROM '/crash_rates.csv' DELIMITER ',' CSV HEADER;


### PR DESCRIPTION
This adds instructions for running an exploratory GUI for MacroBase over a prepackaged `crash_rates.csv` dataset. 